### PR TITLE
Upgrade to from Node8 to Node 16 (LTS)

### DIFF
--- a/server/.npmignore
+++ b/server/.npmignore
@@ -66,6 +66,7 @@ lib/**/*.test.js*
 packages
 
 venus-server-*.tgz
+venus-docker-grafana-server-*.tgz
 
 ./config.json*
 ./secrets.json*

--- a/server/package.json
+++ b/server/package.json
@@ -34,7 +34,7 @@
   "author": "Scott Bender <scott@scottbender.net>",
   "license": "MIT",
   "engines": {
-    "node": "8"
+    "node": "16"
   },
   "dependencies": {
     "basic-auth": "^2.0.1",
@@ -62,7 +62,7 @@
     "babel-plugin-transform-object-rest-spread": "6.26.0",
     "babel-preset-env": "1.6.1",
     "babel-preset-react": "6.24.1",
-    "bootstrap": ">=4.1.2",
+    "bootstrap": "^4.6.1",
     "chart.js": "2.7.1",
     "copy-webpack-plugin": "4.2.1",
     "css-hot-loader": "1.3.3",
@@ -79,7 +79,7 @@
     "html-webpack-plugin": "2.30.1",
     "husky": "^1.0.0",
     "lint-staged": "^8.0.4",
-    "node-sass": "4.7.1",
+    "node-sass": "^4.14.1",
     "prettier-standard": "^8.0.0",
     "react": "16.1.1",
     "react-chartjs-2": "2.6.4",
@@ -98,7 +98,7 @@
     "style-loader": "0.19.0",
     "uglify-js": "3.1.10",
     "url-loader": "0.6.2",
-    "webpack": "^3.8.1",
+    "webpack": "^3.12.0",
     "webpack-dev-server": "2.9.4"
   },
   "husky": {


### PR DESCRIPTION
- Required version must be Node 16 (current LTS)
- Pin some versions in order to get a working setup
- Added venus-docker-grafana-server-*.tgz to .nmpignore to make sure old releases are not packaged.